### PR TITLE
Add AWS_S3_BUCKET_CREATE option to create bucket if NoSuchBucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ENV STORAGE_PROVIDER='' \
     CRON_SCHEDULE='' \
     AWS_ACCESS_KEY_ID='' \
     AWS_SECRET_ACCESS_KEY='' \
+    AWS_S3_BUCKET_CREATE='false' \
     AWS_S3_BUCKET_NAME='' \
     AWS_S3_PATH='/' \
     AWS_DEFAULT_REGION='us-east-1' \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 | AWS_ACCESS_KEY_ID               | null                | backup, restore        | yes       | tarball, sync   | AWS access key. Eg: AKRJPMI3QYCARJCRF4VF                         |
 | AWS_SECRET_ACCESS_KEY           | null                | backup, restore        | yes       | tarball, sync   | AWS secret key. Eg: VCsrO7aVulGuiUdXbS31jtQA4iRTVgi4scftJAJr     |
 | AWS_S3_BUCKET_NAME              | null                | backup, restore        | yes       | tarball, sync   | S3 bucket name. Eg: s3://my-bucket-backup/                       |
+| AWS_S3_BUCKET_CREATE            | false               | backup                 | no        | tarball, sync   | Boolean to indicate if we create the bucket (if not exists)      |
 | AWS_S3_PATH                     | /                   | backup, restore        | no        | tarball, sync   | Relative path for bucket S3. Eg: (AWS_S3_BUCKET_NAME)/jenkins/   |
 | AWS_DEFAULT_REGION              | us-east-1           | backup, restore        | no        | tarball, sync   | Default region bucket. Eg: (sa-east-1)                           |
 | AWS_S3_OPTIONS                  | null                | backup, restore        | no        | tarball, sync   | AWS S3 options parameters. See in [AWS CLI S3]                   |
@@ -236,6 +237,14 @@ Run [Backup|Restore] without gzip compression:
 docker run --rm \
 ........
 -e GZIP_COMPRESSION=false \
+helicopterizer [backup|restore] --tarball
+```
+
+Run [Backup|Restore] with bucket creation (if NoSuchBucket):
+```
+docker run --rm \
+........
+-e AWS_S3_BUCKET_CREATE=true \
 helicopterizer [backup|restore] --tarball
 ```
 

--- a/scripts/core/helper.sh
+++ b/scripts/core/helper.sh
@@ -93,6 +93,7 @@ printEnvs(){
   echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
   echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
   echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+  echo "AWS_S3_BUCKET_CREATE=$AWS_S3_BUCKET_CREATE"
   echo "AWS_S3_BUCKET_NAME=$AWS_S3_BUCKET_NAME"
   echo "AWS_S3_PATH=$AWS_S3_PATH"
   echo "AWS_S3_OPTIONS=$AWS_S3_OPTIONS"
@@ -188,4 +189,17 @@ mountUriS3(){
   s3Uri=$(removeSlashUri $s3Uri)
   s3Uri="s3://$s3Uri"
   echo "$s3Uri"
+}
+
+createS3Bucket(){
+  # Check if create is required
+  if [ "$AWS_S3_BUCKET_CREATE" = "true" ]; then
+    local bucketS3Uri="s3://$AWS_S3_BUCKET_NAME"
+    # Test if bucket doesn't exists
+    if aws s3 ls "s3://$AWS_S3_BUCKET_NAME" 2>&1 | grep -q 'NoSuchBucket'; then
+      # Create bucket
+      local s3BucketCreationResult=$(aws s3 mb "$bucketS3Uri")
+      echo "$s3BucketCreationResult"
+    fi
+  fi
 }

--- a/scripts/provider/aws/sync/upload.sh
+++ b/scripts/provider/aws/sync/upload.sh
@@ -12,10 +12,12 @@ SyncUploadToS3(){
   echo "$s3Result"
 }
 
-
 uploadSync(){
   #Call to mount uri S3.
   s3Uri=$(mountUriS3 "/" $AWS_S3_BUCKET_NAME $AWS_S3_PATH)
+
+  local createS3BucketResult=$(createS3Bucket)
+  echo "$createS3BucketResult"
 
   echo "Starting Upload Sync from: $DATA_PATH/ to $s3Uri/"
   local s3Result=$(SyncUploadToS3)

--- a/scripts/provider/aws/tarball/upload.sh
+++ b/scripts/provider/aws/tarball/upload.sh
@@ -15,6 +15,9 @@ uploadTarball(){
   #Call to mount uri S3.
   s3Uri=$(mountUriS3 $1 $AWS_S3_BUCKET_NAME $AWS_S3_PATH)
 
+  local createS3BucketResult=$(createS3Bucket)
+  echo "$createS3BucketResult"
+
   echo "Starting Upload Tarball from: /tmp/$1 to $s3Uri"
   local s3Result=$(uploadToS3 $1)
   echo "$s3Result"


### PR DESCRIPTION
It resolves #13 

Create a new option `AWS_S3_BUCKET_CREATE` (`false` as default) to set-up the creation of a bucked which doesn't exists.
Available on `backup` method and for `sync` + `tarball` target.
